### PR TITLE
Filenames in Git repo have \ as file separator on Windows (#4) 

### DIFF
--- a/git-remote-hg
+++ b/git-remote-hg
@@ -19,6 +19,7 @@ from mercurial import changegroup
 import re
 import sys
 import os
+import posixpath
 import json
 import shutil
 import subprocess
@@ -265,10 +266,10 @@ class Parser:
         return (user, int(date), -tz)
 
 def fix_file_path(path):
-    path = os.path.normpath(path)
+    path = posixpath.normpath(path)
     if not os.path.isabs(path):
         return path
-    return os.path.relpath(path, '/')
+    return posixpath.relpath(path, '/')
 
 def export_files(files):
     final = []


### PR DESCRIPTION
In one of forks this promblem solved. 
Please, merge with it and close issue #4 and the pull request.
