### PR TITLE
"Branch name doesn't conform to GIT standards" (moving felipec:#7)

### DIFF
--- a/git-remote-hg
+++ b/git-remote-hg
@@ -85,9 +85,11 @@ def hgbin(n):
     return node.bin(n)
 
 def hgref(ref):
+    ref = re.sub('_\._$', '.', ref)
     return ref.replace('___', ' ')
 
 def gitref(ref):
+    ref = re.sub('\.$', '_._', ref)
     return ref.replace(' ', '___')
 
 def check_version(*check):


### PR DESCRIPTION
This request is transferred from the old project, and may be more relevant here. 
See the discussion in the old issue felipec:[#7](https://github.com/felipec/git-remote-hg/pull/7)
# 

**git-remote-hg: Fix . at end of ref**

Any Mercurial tag/branch/bookmark that ended with a period would be
rejected by fast-import.  The repository could be cloned, but any
further fetch would fail.

Use a similar trick to the space handling, but only when the period is
at the end of the ref.

Probably need a more general solution to this problem.

Signed-off-by: Brian Gernhardt brian@gernhardtsoftware.com
