### PR TITLE
"Added error checking for non hg repo" (moving felipec:#44)

### DIFF
--- a/git-remote-hg
+++ b/git-remote-hg
@@ -443,7 +443,10 @@ def get_repo(url, alias):
     extensions.loadall(myui)
 
     if hg.islocal(url) and not os.environ.get('GIT_REMOTE_HG_TEST_REMOTE'):
-        repo = hg.repository(myui, url)
+        try:
+          repo = hg.repository(myui, url)
+        except error.RepoError, e:
+          die("Can't connect to hg repo: %s.\n(Is it already git?)", e)
         if not os.path.exists(dirname):
             os.makedirs(dirname)
     else:


### PR DESCRIPTION
This request is transferred from the old project, and may be more relevant here. 
See the discussion in the old issue felipec:[#44](https://github.com/felipec/git-remote-hg/pull/44)
