### PR TITLE
git-remote-hg: fallback on simplejson if json import fails

### DIFF
--- a/git-remote-hg
+++ b/git-remote-hg
@@ -20,7 +20,10 @@ import re
 import sys
 import os
 import posixpath
-import json
+try:
+    import json
+except ImportError:
+    import simplejson as json 
 import shutil
 import subprocess
 import urllib


### PR DESCRIPTION
On my old gentoo I have no json module. I think this can be a good idea to handle the fallback.